### PR TITLE
Add React Native setup script

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -38,6 +38,10 @@ docker-compose -f docker-compose.test.yml down
 
 ## Frontend
 The React dashboard resides in `front/dashboard`. See its `README.md` for package.json scripts and development instructions.
+The repository also contains `scripts/setup_mobile_app.sh` which bootstraps a
+React Native project described in `docs/react_native_migration.md`. Run this
+script **while network access is available** to create the `mobile/` directory
+and install dependencies.
 
 ## Important notes
 - Keep sensitive information such as credentials out of commits. Environment variables are stored in `.env.prod`.

--- a/README
+++ b/README
@@ -47,6 +47,18 @@
    ```
    - The frontend will be available at: http://localhost:3000/
 
+### Mobile (React Native)
+
+Run the following script **while network access is available** to bootstrap the
+new React Native application using Expo and install all required packages:
+
+```sh
+./scripts/setup_mobile_app.sh
+```
+
+This will create a `mobile/` directory with the Expo project and install the
+dependencies listed in `docs/react_native_migration.md`.
+
 ---
 
 ### Notes

--- a/scripts/setup_mobile_app.sh
+++ b/scripts/setup_mobile_app.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Bootstrap the React Native mobile app.
+# Run this script while network access is available.
+# It installs Expo CLI, creates the mobile app directory via Expo, and installs
+# all dependencies required for development.
+set -e
+
+# Install pnpm globally if not present
+if ! command -v pnpm >/dev/null; then
+  npm install -g pnpm
+fi
+
+# Install Expo CLI if not present
+if ! command -v expo >/dev/null; then
+  pnpm install -g expo-cli
+fi
+
+# Create the mobile app if it does not exist
+if [ ! -d "mobile" ]; then
+  pnpm create expo-app mobile --template
+fi
+
+# Install mobile dependencies
+cd mobile
+pnpm install
+
+# Core libraries
+pnpm add @react-navigation/native @reduxjs/toolkit @tanstack/react-query \
+  react-native-paper react-hook-form yup
+
+# Additional tooling
+pnpm add expo-router @shopify/flash-list nativewind react-native-reanimated \
+  moti zod @sentry/react-native
+
+# Dev dependencies
+pnpm add -D detox @storybook/react-native openapi-zod-client
+
+cd ..
+
+echo "Mobile app setup complete."
+


### PR DESCRIPTION
## Summary
- add `scripts/setup_mobile_app.sh` for bootstrapping React Native mobile app
- document running the script in the README
- mention the script in AGENT guidelines

## Testing
- `docker-compose -f docker-compose.test.yml run --build test` *(fails: `docker-compose` not found)*