### PR TITLE
Implement chat functionality

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -6,4 +6,14 @@ Copyright (c) 2019 - present AppSeed.us
 
 from django.contrib import admin
 
-# Register your models here.
+from .models import Conversation, Message
+
+
+@admin.register(Conversation)
+class ConversationAdmin(admin.ModelAdmin):
+    list_display = ("id", "user", "created_at")
+
+
+@admin.register(Message)
+class MessageAdmin(admin.ModelAdmin):
+    list_display = ("id", "conversation", "sender", "content_type", "timestamp")

--- a/app/models.py
+++ b/app/models.py
@@ -5,6 +5,43 @@ Copyright (c) 2019 - present AppSeed.us
 """
 
 from django.db import models
+from django.conf import settings
 
-# Create your models here.
+
+class Conversation(models.Model):
+    """Represents a chat session for a user."""
+
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self) -> str:
+        return f"Conversation {self.pk} for {self.user}"
+
+
+class Message(models.Model):
+    """Single chat message."""
+
+    USER = "user"
+    AGENT = "agent"
+
+    SENDER_CHOICES = [
+        (USER, "User"),
+        (AGENT, "Agent"),
+    ]
+
+    conversation = models.ForeignKey(
+        Conversation, related_name="messages", on_delete=models.CASCADE
+    )
+    sender = models.CharField(max_length=10, choices=SENDER_CHOICES)
+    content_type = models.CharField(max_length=20, default="text")
+    payload = models.JSONField(default=dict)
+    timestamp = models.DateTimeField(auto_now_add=True)
+    status = models.CharField(max_length=20, default="sent")
+
+    class Meta:
+        ordering = ["timestamp"]
+
+    def __str__(self) -> str:
+        return f"{self.sender} - {self.payload}"
+
 

--- a/app/serializers.py
+++ b/app/serializers.py
@@ -1,6 +1,8 @@
 from dj_rest_auth.registration.serializers import RegisterSerializer
 from rest_framework import serializers
 
+from .models import Conversation, Message
+
 
 class CustomRegisterSerializer(RegisterSerializer):
     first_name = serializers.CharField()
@@ -21,5 +23,26 @@ class CustomRegisterSerializer(RegisterSerializer):
 
     def create(self, validated_data):
         pass
+
+
+class ConversationSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Conversation
+        fields = ["id", "user", "created_at"]
+
+
+class MessageSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Message
+        fields = [
+            "id",
+            "conversation",
+            "sender",
+            "content_type",
+            "payload",
+            "timestamp",
+            "status",
+        ]
+
 
 

--- a/app/tests/test_chat.py
+++ b/app/tests/test_chat.py
@@ -1,0 +1,25 @@
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient
+from django.urls import reverse
+from django.test import TestCase
+
+from app.models import Conversation, Message
+
+class ChatAPITest(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(username="test", password="pass")
+        self.client = APIClient()
+        self.client.force_authenticate(self.user)
+
+    def test_send_message_creates_reply(self):
+        res = self.client.post("/api/chat/send/", {"text": "hello"}, format="json")
+        self.assertEqual(res.status_code, 200)
+        conv = Conversation.objects.get(user=self.user)
+        self.assertEqual(conv.messages.count(), 2)
+
+    def test_history_returns_messages(self):
+        conv = Conversation.objects.create(user=self.user)
+        Message.objects.create(conversation=conv, sender="user", content_type="text", payload={"text": "hi"})
+        res = self.client.get("/api/chat/history/")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.data), 1)

--- a/app/urls.py
+++ b/app/urls.py
@@ -28,6 +28,8 @@ urlpatterns = [
     path('api/user_goals/', views.UserTagGoalView.as_view()),
     path('api/users/', views.UserView.as_view()),
     path('user_transactions_names', views.UserTransactionsNames.as_view()),
+    path('api/chat/send/', views.ChatSendView.as_view()),
+    path('api/chat/history/', views.ChatHistoryView.as_view()),
 
     # path('', views.index, name='home'),
     # re_path(r'^.*\.html', views.pages, name='pages'),

--- a/app/views.py
+++ b/app/views.py
@@ -40,6 +40,8 @@ from telegram_bot import telegram_bot_api
 from .date_utils import date_in_bill_month, next_bill_date, end_month
 from .forms import TransactionModelForm
 from .utils import expenses_transactions, average_income
+from .models import Conversation, Message
+from .serializers import MessageSerializer
 
 # from app.graph.graph_api import monthly_average_by_category, line_fig_by_tag_by_month, line_fig_by_month, \
 #     Tag, \
@@ -497,5 +499,40 @@ def reformat_figs(data):
             fig.update_layout(margin=dict(l=0, r=0, t=0, b=0))
             data[name] = fig.to_html(full_html=False, config={'displayModeBar': False})
     return data
+
+
+class ChatHistoryView(APIView):
+    """Return conversation history for the authenticated user."""
+
+    serializer_class = MessageSerializer
+
+    def get(self, request):
+        conversation, _ = Conversation.objects.get_or_create(user=request.user)
+        messages = conversation.messages.all()
+        return Response(MessageSerializer(messages, many=True).data)
+
+
+class ChatSendView(APIView):
+    """Accept a user message and return the agent response."""
+
+    serializer_class = MessageSerializer
+
+    def post(self, request):
+        conversation, _ = Conversation.objects.get_or_create(user=request.user)
+        text = request.data.get("text", "")
+        user_msg = Message.objects.create(
+            conversation=conversation,
+            sender=Message.USER,
+            content_type="text",
+            payload={"text": text},
+        )
+
+        agent_msg = Message.objects.create(
+            conversation=conversation,
+            sender=Message.AGENT,
+            content_type="text",
+            payload={"text": f"Echo: {text}"},
+        )
+        return Response(MessageSerializer(agent_msg).data)
 
 

--- a/front/FinanceAgent/src/navigation/MainNavigator.tsx
+++ b/front/FinanceAgent/src/navigation/MainNavigator.tsx
@@ -3,6 +3,7 @@ import { createBottomTabNavigator } from "@react-navigation/bottom-tabs"
 import { useTheme } from "react-native-paper"
 import Icon from "react-native-vector-icons/MaterialCommunityIcons"
 import DashboardScreen from "../screens/main/DashboardScreen"
+import ChatScreen from "../screens/main/ChatScreen"
 import TransactionsScreen from "../screens/main/TransactionsScreen"
 import AccountsScreen from "../screens/main/AccountsScreen"
 import SettingsScreen from "../screens/main/SettingsScreen"
@@ -19,7 +20,9 @@ export default function MainNavigator() {
         tabBarIcon: ({ focused, color, size }) => {
           let iconName
 
-          if (route.name === "Dashboard") {
+          if (route.name === "Chat") {
+            iconName = focused ? "message" : "message-outline"
+          } else if (route.name === "Dashboard") {
             iconName = focused ? "view-dashboard" : "view-dashboard-outline"
           } else if (route.name === "Transactions") {
             iconName = focused ? "swap-horizontal" : "swap-horizontal"
@@ -44,6 +47,7 @@ export default function MainNavigator() {
         },
       })}
     >
+      <Tab.Screen name="Chat" component={ChatScreen} />
       <Tab.Screen name="Dashboard" component={DashboardScreen} />
       <Tab.Screen name="Transactions" component={TransactionsScreen} />
       <Tab.Screen name="Accounts" component={AccountsScreen} />

--- a/front/FinanceAgent/src/screens/main/ChatScreen.tsx
+++ b/front/FinanceAgent/src/screens/main/ChatScreen.tsx
@@ -1,0 +1,85 @@
+"use client"
+import { useEffect, useState } from 'react'
+import { View, StyleSheet, FlatList, TextInput } from 'react-native'
+import { Text, Button, useTheme } from 'react-native-paper'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { chatService } from '../../services/chatService'
+import type { ChatMessage } from '../../types/chat'
+
+export default function ChatScreen() {
+  const [messages, setMessages] = useState<ChatMessage[]>([])
+  const [text, setText] = useState('')
+  const theme = useTheme()
+
+  useEffect(() => {
+    loadHistory()
+  }, [])
+
+  const loadHistory = async () => {
+    try {
+      const history = await chatService.fetchHistory()
+      setMessages(history)
+    } catch (err) {
+      console.error('Failed to load history', err)
+    }
+  }
+
+  const send = async () => {
+    if (!text.trim()) return
+    try {
+      const reply = await chatService.sendMessage(text)
+      const userMessage: ChatMessage = {
+        id: Date.now(),
+        conversation: reply.conversation,
+        sender: 'user',
+        content_type: 'text',
+        payload: { text },
+        timestamp: new Date().toISOString(),
+        status: 'sent'
+      }
+      setMessages(prev => [...prev, userMessage, reply])
+      setText('')
+    } catch (err) {
+      console.error('Send failed', err)
+    }
+  }
+
+  const renderItem = ({ item }: { item: ChatMessage }) => (
+    <View
+      style={[
+        styles.message,
+        item.sender === 'user' ? styles.user : styles.agent,
+        {
+          backgroundColor:
+            item.sender === 'user' ? theme.colors.primary : theme.colors.surfaceVariant
+        }
+      ]}
+    >
+      <Text style={{ color: item.sender === 'user' ? '#fff' : theme.colors.onSurface }}>
+        {item.payload.text}
+      </Text>
+    </View>
+  )
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <FlatList data={messages} renderItem={renderItem} keyExtractor={m => m.id.toString()} contentContainerStyle={styles.list} />
+      <View style={styles.inputRow}>
+        <TextInput style={styles.input} value={text} onChangeText={setText} placeholder="Message" />
+        <Button mode="contained" onPress={send}>
+          Send
+        </Button>
+      </View>
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  list: { padding: 16 },
+  message: { padding: 8, borderRadius: 8, marginBottom: 8, maxWidth: '80%' },
+  user: { alignSelf: 'flex-end' },
+  agent: { alignSelf: 'flex-start' },
+  inputRow: { flexDirection: 'row', padding: 8, alignItems: 'center' },
+  input: { flex: 1, marginRight: 8 }
+})

--- a/front/FinanceAgent/src/services/chatService.ts
+++ b/front/FinanceAgent/src/services/chatService.ts
@@ -1,0 +1,29 @@
+import axios from 'axios'
+import { secureStorage } from '../utils/secureStorage'
+import type { ChatMessage } from '../types/chat'
+
+// TODO: replace with real backend url
+const API_BASE_URL = 'http://localhost:8000'
+
+class ChatService {
+  private axiosInstance = axios.create({ baseURL: API_BASE_URL })
+
+  private async authHeaders() {
+    const token = await secureStorage.getToken()
+    return token ? { Authorization: `Token ${token}` } : {}
+  }
+
+  async sendMessage(text: string): Promise<ChatMessage> {
+    const headers = await this.authHeaders()
+    const res = await this.axiosInstance.post('/api/chat/send/', { text }, { headers })
+    return res.data
+  }
+
+  async fetchHistory(): Promise<ChatMessage[]> {
+    const headers = await this.authHeaders()
+    const res = await this.axiosInstance.get('/api/chat/history/', { headers })
+    return res.data
+  }
+}
+
+export const chatService = new ChatService()

--- a/front/FinanceAgent/src/types/chat.ts
+++ b/front/FinanceAgent/src/types/chat.ts
@@ -1,0 +1,9 @@
+export interface ChatMessage {
+  id: number
+  conversation: number
+  sender: 'user' | 'agent'
+  content_type: string
+  payload: any
+  timestamp: string
+  status: string
+}


### PR DESCRIPTION
## Summary
- add Conversation and Message models with admin configuration
- expose REST endpoints for chat history and sending messages
- implement ChatScreen and chat service in FinanceAgent app
- register Chat tab in navigation
- include API tests for chat features

## Testing
- `python manage.py test app.tests.test_chat` *(fails: ModuleNotFoundError: No module named 'django')*