### PR TITLE
Add prompts and schema validation for finance agents

### DIFF
--- a/agents/base.py
+++ b/agents/base.py
@@ -1,4 +1,7 @@
 from typing import Tuple, Dict
+import json
+from pathlib import Path
+from jsonschema import validate
 
 from app.models import Message
 
@@ -7,7 +10,29 @@ class BaseAgent:
     """Simple base class for all agents."""
 
     name: str = "agent"
+    schema_file: str | None = None
 
     def handle_message(self, text: str) -> Tuple[str, Dict]:
         """Process the message and return content type and payload."""
         raise NotImplementedError
+
+    def system_prompt(self) -> str:
+        """Return the system prompt for this agent if available."""
+        path = Path(__file__).parent / "prompt" / "system_prompt" / f"{self.name}.md"
+        return path.read_text() if path.exists() else ""
+
+    def load_schema(self) -> Dict:
+        """Load the JSON schema for this agent if defined."""
+        if not self.schema_file:
+            return {}
+        path = Path(__file__).parent / "schema" / self.schema_file
+        if path.exists():
+            with open(path) as f:
+                return json.load(f)
+        return {}
+
+    def validate_payload(self, payload: Dict) -> None:
+        """Validate the payload against the agent schema."""
+        schema = self.load_schema()
+        if schema:
+            validate(instance=payload, schema=schema)

--- a/agents/cash_flow.py
+++ b/agents/cash_flow.py
@@ -4,6 +4,16 @@ from app.models import Message
 
 class CashFlowAgent(BaseAgent):
     name = "cash_flow"
+    schema_file = "CashFlowLedger.json"
 
     def handle_message(self, text: str):
-        return Message.TEXT, {"text": "Here is your cash flow summary."}
+        payload = {
+            "ledger_id": "00000000-0000-0000-0000-000000000000",
+            "snapshot_id": "00000000-0000-0000-0000-000000000000",
+            "period_start": "2024-01-01",
+            "period_end": "2024-01-31",
+            "currency": "USD",
+            "transactions": []
+        }
+        self.validate_payload(payload)
+        return Message.TEXT, payload

--- a/agents/goal_setting.py
+++ b/agents/goal_setting.py
@@ -4,6 +4,9 @@ from app.models import Message
 
 class GoalSettingAgent(BaseAgent):
     name = "goal_setting"
+    schema_file = "GoalList.json"
 
     def handle_message(self, text: str):
-        return Message.TEXT, {"text": "Let's talk about your financial goals."}
+        payload = {"goals": []}
+        self.validate_payload(payload)
+        return Message.TEXT, payload

--- a/agents/investment.py
+++ b/agents/investment.py
@@ -4,6 +4,16 @@ from app.models import Message
 
 class InvestmentAgent(BaseAgent):
     name = "investment"
+    schema_file = "InvestmentPortfolio.json"
 
     def handle_message(self, text: str):
-        return Message.TEXT, {"text": "Final investment advice."}
+        payload = {
+            "portfolio_id": "00000000-0000-0000-0000-000000000000",
+            "snapshot_date": "2024-01-01",
+            "currency": "USD",
+            "target_allocation": {},
+            "current_allocation": {},
+            "holdings": []
+        }
+        self.validate_payload(payload)
+        return Message.TEXT, payload

--- a/agents/onboarding.py
+++ b/agents/onboarding.py
@@ -4,6 +4,7 @@ from app.models import Message
 
 class OnboardingAgent(BaseAgent):
     name = "onboarding"
+    schema_file = "BaselineSnapshot.json"
 
     def handle_message(self, text: str):
         lower = text.lower()
@@ -11,4 +12,17 @@ class OnboardingAgent(BaseAgent):
             return Message.BUTTONS, {"buttons": ["Yes", "No"]}
         if "image" in lower:
             return Message.IMAGE, {"url": "https://placekitten.com/300/200"}
-        return Message.TEXT, {"text": f"Welcome! {text}"}
+        payload = {
+            "snapshot_id": "00000000-0000-0000-0000-000000000000",
+            "user_id": "00000000-0000-0000-0000-000000000000",
+            "created_at": "2024-01-01T00:00:00Z",
+            "currency": "USD",
+            "accounts": [],
+            "assets": [],
+            "liabilities": [],
+            "monthly_income": 0,
+            "monthly_expenses": 0,
+            "notes": ""
+        }
+        self.validate_payload(payload)
+        return Message.TEXT, payload

--- a/agents/prompt/system_prompt/cash_flow.md
+++ b/agents/prompt/system_prompt/cash_flow.md
@@ -1,0 +1,4 @@
+# Cash-Flow Agent System Prompt
+You are the CASH-FLOW agent.
+Return a JSON object matching the `CashFlowLedger` schema.
+Provide only the JSON.

--- a/agents/prompt/system_prompt/goal_setting.md
+++ b/agents/prompt/system_prompt/goal_setting.md
@@ -1,0 +1,4 @@
+# Goal-Setting Agent System Prompt
+You are the GOAL-SETTING agent.
+Respond with a JSON object that conforms to the `GoalList` schema.
+Only output the JSON object.

--- a/agents/prompt/system_prompt/investment.md
+++ b/agents/prompt/system_prompt/investment.md
@@ -1,0 +1,4 @@
+# Investment Agent System Prompt
+You are the INVESTMENT agent.
+Return a JSON object as defined by the `InvestmentPortfolio` schema.
+Output only the JSON.

--- a/agents/prompt/system_prompt/onboarding.md
+++ b/agents/prompt/system_prompt/onboarding.md
@@ -1,0 +1,4 @@
+# Onboarding Agent System Prompt
+You are the ONBOARDING agent in the personal-finance assistant.
+Your only output is a JSON object that follows the `BaselineSnapshot` schema.
+Return only the JSON object.

--- a/agents/prompt/system_prompt/reporting.md
+++ b/agents/prompt/system_prompt/reporting.md
@@ -1,0 +1,4 @@
+# Reporting Agent System Prompt
+You are the REPORTING agent.
+Produce a JSON object that satisfies the `Report` schema.
+Only return the JSON object.

--- a/agents/prompt/system_prompt/safety.md
+++ b/agents/prompt/system_prompt/safety.md
@@ -1,0 +1,4 @@
+# Safety Agent System Prompt
+You are the SAFETY agent.
+Reply with a JSON object compliant with the `SafetyLayer` schema.
+Return nothing but the JSON.

--- a/agents/prompt/system_prompt/tax_pension.md
+++ b/agents/prompt/system_prompt/tax_pension.md
@@ -1,0 +1,4 @@
+# Tax & Pension Agent System Prompt
+You are the TAX & PENSION agent.
+Produce a JSON object following the `TaxPensionProfile` schema.
+Output only the JSON.

--- a/agents/reporting.py
+++ b/agents/reporting.py
@@ -4,6 +4,16 @@ from app.models import Message
 
 class ReportingAgent(BaseAgent):
     name = "reporting"
+    schema_file = "Report.json"
 
     def handle_message(self, text: str):
-        return Message.CHART, {"labels": ["Jan", "Feb"], "values": [10, 20]}
+        payload = {
+            "report_id": "00000000-0000-0000-0000-000000000000",
+            "type": "net_worth",
+            "generated_at": "2024-01-01T00:00:00Z",
+            "source_refs": [],
+            "chart_url": "https://example.com/chart.png",
+            "summary_markdown": "Example report"
+        }
+        self.validate_payload(payload)
+        return Message.CHART, payload

--- a/agents/safety.py
+++ b/agents/safety.py
@@ -4,6 +4,23 @@ from app.models import Message
 
 class SafetyAgent(BaseAgent):
     name = "safety"
+    schema_file = "SafetyLayer.json"
 
     def handle_message(self, text: str):
-        return Message.TEXT, {"text": "Safety checks complete."}
+        payload = {
+            "safety_id": "00000000-0000-0000-0000-000000000000",
+            "snapshot_id": "00000000-0000-0000-0000-000000000000",
+            "emergency_months_required": 3,
+            "emergency_months_current": 0,
+            "insurance_coverages": [
+                {
+                    "policy_id": "00000000-0000-0000-0000-000000000000",
+                    "coverage_type": "other",
+                    "coverage_amount": 0,
+                    "premium": 0,
+                    "status": "active"
+                }
+            ]
+        }
+        self.validate_payload(payload)
+        return Message.TEXT, payload

--- a/agents/tax_pension.py
+++ b/agents/tax_pension.py
@@ -4,6 +4,14 @@ from app.models import Message
 
 class TaxPensionAgent(BaseAgent):
     name = "tax_pension"
+    schema_file = "TaxPensionProfile.json"
 
     def handle_message(self, text: str):
-        return Message.TEXT, {"text": "Here is your tax and pension info."}
+        payload = {
+            "profile_id": "00000000-0000-0000-0000-000000000000",
+            "tax_year": 2024,
+            "gross_income": 0,
+            "pension_plans": []
+        }
+        self.validate_payload(payload)
+        return Message.TEXT, payload

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,3 +39,4 @@ boto3
 drf-spectacular
 langchain
 langgraph
+jsonschema


### PR DESCRIPTION
## Summary
- add simple system prompts for each agent
- validate agent outputs using JSON Schema
- provide example payloads for each agent
- include jsonschema in requirements

## Testing
- `pytest -q` *(fails: ImproperlyConfigured)*