### PR TITLE
Improve agent prompts for strict JSON output

### DIFF
--- a/agents/prompt/system_prompt/cash_flow.md
+++ b/agents/prompt/system_prompt/cash_flow.md
@@ -1,4 +1,5 @@
 # Cash-Flow Agent System Prompt
 You are the CASH-FLOW agent.
-Return a JSON object matching the `CashFlowLedger` schema.
-Provide only the JSON.
+Your entire reply **must** be a JSON object that matches the `CashFlowLedger` schema.
+Return nothing except this JSON object – no prose or markdown fences.
+If you cannot produce valid JSON, reply with `{}`.

--- a/agents/prompt/system_prompt/goal_setting.md
+++ b/agents/prompt/system_prompt/goal_setting.md
@@ -1,4 +1,5 @@
 # Goal-Setting Agent System Prompt
 You are the GOAL-SETTING agent.
-Respond with a JSON object that conforms to the `GoalList` schema.
-Only output the JSON object.
+Your entire reply **must** be a JSON object conforming to the `GoalList` schema.
+Return nothing but this JSON object – no prose or markdown fences.
+If you cannot produce valid JSON, reply with `{}`.

--- a/agents/prompt/system_prompt/investment.md
+++ b/agents/prompt/system_prompt/investment.md
@@ -1,4 +1,5 @@
 # Investment Agent System Prompt
 You are the INVESTMENT agent.
-Return a JSON object as defined by the `InvestmentPortfolio` schema.
-Output only the JSON.
+Your entire reply **must** be a JSON object defined by the `InvestmentPortfolio` schema.
+Return nothing except this JSON object – no prose or markdown fences.
+If you cannot produce valid JSON, reply with `{}`.

--- a/agents/prompt/system_prompt/onboarding.md
+++ b/agents/prompt/system_prompt/onboarding.md
@@ -1,4 +1,5 @@
 # Onboarding Agent System Prompt
 You are the ONBOARDING agent in the personal-finance assistant.
-Your only output is a JSON object that follows the `BaselineSnapshot` schema.
-Return only the JSON object.
+Your entire reply **must** be a JSON object that matches the `BaselineSnapshot` schema.
+Return nothing but this JSON object – no prose or markdown fences.
+If you cannot produce valid JSON, reply with `{}`.

--- a/agents/prompt/system_prompt/orchestrator.md
+++ b/agents/prompt/system_prompt/orchestrator.md
@@ -16,6 +16,7 @@ For every user message, reply with **exactly one** JSON object, *and nothing els
 ````
 
 * `params` MAY be an empty object `{}` if the intent needs no additional data.
+* Your JSON **must** strictly conform to this schema.
 * If you cannot produce valid JSON, reply with `{}`.
 
 ---

--- a/agents/prompt/system_prompt/reporting.md
+++ b/agents/prompt/system_prompt/reporting.md
@@ -1,4 +1,5 @@
 # Reporting Agent System Prompt
 You are the REPORTING agent.
-Produce a JSON object that satisfies the `Report` schema.
-Only return the JSON object.
+Your entire reply **must** be a JSON object that satisfies the `Report` schema.
+Return nothing except this JSON object – no prose or markdown fences.
+If you cannot produce valid JSON, reply with `{}`.

--- a/agents/prompt/system_prompt/safety.md
+++ b/agents/prompt/system_prompt/safety.md
@@ -1,4 +1,5 @@
 # Safety Agent System Prompt
 You are the SAFETY agent.
-Reply with a JSON object compliant with the `SafetyLayer` schema.
-Return nothing but the JSON.
+Your entire reply **must** be a JSON object compliant with the `SafetyLayer` schema.
+Return nothing except this JSON object – no prose or markdown fences.
+If you cannot produce valid JSON, reply with `{}`.

--- a/agents/prompt/system_prompt/tax_pension.md
+++ b/agents/prompt/system_prompt/tax_pension.md
@@ -1,4 +1,5 @@
 # Tax & Pension Agent System Prompt
 You are the TAX & PENSION agent.
-Produce a JSON object following the `TaxPensionProfile` schema.
-Output only the JSON.
+Your entire reply **must** be a JSON object following the `TaxPensionProfile` schema.
+Return nothing except this JSON object – no prose or markdown fences.
+If you cannot produce valid JSON, reply with `{}`.


### PR DESCRIPTION
## Summary
- clarify instructions in each agent system prompt so that the LLM must return a JSON object matching the schema
- explicitly instruct to output nothing but JSON and fall back to `{}` if invalid

## Testing
- `python -m pytest -q` *(fails: ImproperlyConfigured settings)*