### PR TITLE
Add chart image/data handling

### DIFF
--- a/agents/reporting.py
+++ b/agents/reporting.py
@@ -29,26 +29,40 @@ class ReportingAgent(BaseAgent):
     schema_file = "Report.json"
 
     def handle_message(self, text: str):
-        """Generate charts based on user request and return base64 encoded PNG."""
-        # For now, we'll generate a sample chart. In production, this would
-        # parse the user request and generate appropriate charts based on actual data.
+        """Generate charts based on user request."""
         
-        # Generate sample chart (monthly expenses by category example)
+        lower = text.lower()
         chart_data = self._generate_sample_chart()
-        
-        # Create the payload following the Report schema
+        categories = [
+            "Food & Dining", "Transportation", "Shopping", "Entertainment",
+            "Bills & Utilities", "Healthcare", "Travel", "Other",
+        ]
+        amounts = [1200, 800, 600, 400, 900, 300, 500, 200]
+        if "chart data" in lower:
+            payload = {
+                "report_id": str(uuid.uuid4()),
+                "type": "budget",
+                "generated_at": datetime.now().isoformat(),
+                "source_refs": ["sample_data"],
+                "labels": categories,
+                "values": amounts,
+                "summary_markdown": "## Monthly Expenses by Category\n\nThis chart shows your spending breakdown by category for the selected period.",
+            }
+            self.validate_payload(payload)
+            return Message.CHART, payload
         payload = {
             "report_id": str(uuid.uuid4()),
-            "type": "budget",  # This would be determined by user request
+            "type": "budget",
             "generated_at": datetime.now().isoformat(),
-            "source_refs": ["sample_data"],  # Would reference actual data sources
+            "source_refs": ["sample_data"],
             "chart_url": f"data:image/png;base64,{chart_data}",
-            "summary_markdown": "## Monthly Expenses by Category\n\nThis chart shows your spending breakdown by category for the selected period."
+            "summary_markdown": "## Monthly Expenses by Category\n\nThis chart shows your spending breakdown by category for the selected period.",
         }
-        
+        if "chart image" in lower:
+            self.validate_payload(payload)
+            return Message.IMAGE, payload
         self.validate_payload(payload)
         return Message.CHART, payload
-
     def _generate_sample_chart(self) -> str:
         """Generate a sample monthly expenses by category bar chart."""
         # Sample data - in production, this would come from actual financial data

--- a/front/FinanceAgent/src/screens/main/ChatScreen.tsx
+++ b/front/FinanceAgent/src/screens/main/ChatScreen.tsx
@@ -211,12 +211,14 @@ export default function ChatScreen() {
         </Text>
       )
     } else if (item.content_type === 'image') {
+      const payload = item.payload as any
+      const imageUrl = payload.url ?? payload.chart_url
       content = (
         <View style={styles.imageContainer}>
-          <Image 
-            source={{ uri: (item.payload as any).url }} 
-            style={styles.messageImage} 
-            resizeMode="cover" 
+          <Image
+            source={{ uri: imageUrl }}
+            style={styles.messageImage}
+            resizeMode="cover"
           />
         </View>
       )

--- a/tests/test_reporting_agent.py
+++ b/tests/test_reporting_agent.py
@@ -144,6 +144,19 @@ class TestReportingAgent:
             assert "chart_url" in payload
             assert payload["chart_url"].startswith("data:image/png;base64,")
 
+    def test_chart_image_branch(self):
+        """Agent should return an image payload when text contains 'chart image'."""
+        content_type, payload = self.agent.handle_message("chart image")
+        assert content_type == Message.IMAGE
+        assert "chart_url" in payload
+        assert payload["chart_url"].startswith("data:image/png;base64,")
+
+    def test_chart_data_branch(self):
+        """Agent should return chart data when text contains 'chart data'."""
+        content_type, payload = self.agent.handle_message("chart data")
+        assert content_type == Message.CHART
+        assert "labels" in payload and "values" in payload
+
     def test_future_method_stubs(self):
         """Test that future implementation methods exist but return None."""
         assert self.agent._generate_net_worth_trend([]) is None


### PR DESCRIPTION
## Summary
- allow ReportingAgent to return charts either as image or as label/value data
- display chart images when backend sends `chart_url` in ChatScreen
- cover new reporting paths with tests

## Testing
- `pytest -q`