### PR TITLE
Add backend chat service layer

### DIFF
--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -84,7 +84,7 @@ class Orchestrator(BaseAgent):
 
         return agent_key
 
-    def handle_message(self, text: str) -> Tuple[str, Dict]:
+    def handle_message(self, text: str, **context) -> Tuple[str, Dict]:
         """Route the message and delegate to the appropriate agent."""
         payload = self.generate_payload(text)
 
@@ -106,4 +106,18 @@ class Orchestrator(BaseAgent):
         if not agent_key:
             agent_key = self._heuristic_route(text)
 
-        return self.agents[agent_key].handle_message(text)
+        kwargs = {}
+
+        if agent_key == "cash_flow":
+            if intent:
+                kwargs["intent"] = intent
+            kwargs.update(
+                transactions=context.get("transactions"),
+                category_map=context.get("category_map"),
+                budget_targets=context.get("budget_targets"),
+            )
+        elif intent:
+            # Other agents currently ignore intent
+            pass
+
+        return self.agents[agent_key].handle_message(text, **kwargs)

--- a/app/services/chat_service.py
+++ b/app/services/chat_service.py
@@ -1,0 +1,116 @@
+"""Backend chat service providing ORM integration for the agent flow."""
+
+from __future__ import annotations
+
+import datetime
+from typing import Iterable, List, Dict, Optional
+
+from django.contrib.auth import get_user_model
+
+from app.models import Conversation, Message
+from myFinance.models import Transaction, TransactionNameTag, TagGoal
+from agents.orchestrator import Orchestrator
+
+
+class ChatService:
+    """Service layer bridging the agent flow and the Django ORM."""
+
+    def __init__(self, orchestrator: Orchestrator | None = None) -> None:
+        self.orchestrator = orchestrator or Orchestrator()
+
+    def get_conversation(self, user: get_user_model()) -> Conversation:
+        """Return existing conversation for user or create one."""
+        conversation, _ = Conversation.objects.get_or_create(user=user)
+        return conversation
+
+    def history(self, user: get_user_model()) -> Iterable[Message]:
+        """Return all messages for the user conversation."""
+        conversation = self.get_conversation(user)
+        return conversation.messages.all()
+
+    # ------------------------------------------------------------------
+    # ORM helpers
+    # ------------------------------------------------------------------
+
+    def get_transactions(
+        self,
+        user: get_user_model(),
+        *,
+        start: Optional[datetime.date] = None,
+        end: Optional[datetime.date] = None,
+    ) -> Iterable[Transaction]:
+        """Return transactions for the user in the optional date range."""
+        qs = Transaction.objects.filter(user=user)
+        if start:
+            qs = qs.filter(date__gte=start)
+        if end:
+            qs = qs.filter(date__lte=end)
+        return qs.order_by("date")
+
+    def serialize_transactions(self, txns: Iterable[Transaction]) -> List[Dict]:
+        """Convert transactions to a list of dicts for agents."""
+        data: List[Dict] = []
+        for txn in txns:
+            data.append(
+                {
+                    "transaction_id": str(txn.pk),
+                    "date": txn.date.isoformat(),
+                    "description": txn.name,
+                    "amount": txn.value,
+                    "currency": "ILS",
+                    "account_id": str(txn.credential_id or "0"),
+                    "category": txn.tag.name if txn.tag else None,
+                    "tags": [txn.tag.name] if txn.tag else [],
+                }
+            )
+        return data
+
+    def get_category_map(self, user: get_user_model()) -> Dict[str, str]:
+        """Return mapping of merchant/description to category."""
+        mapping: Dict[str, str] = {}
+        for item in TransactionNameTag.objects.filter(user=user):
+            if item.tag:
+                mapping[item.transaction_name] = item.tag.name
+        return mapping
+
+    def get_budget_targets(self, user: get_user_model()) -> Dict[str, float]:
+        """Return budget target values per tag name."""
+        return {
+            goal.tag.name: goal.value
+            for goal in TagGoal.objects.filter(user=user).select_related("tag")
+        }
+
+    def build_financial_context(
+        self, user: get_user_model()
+    ) -> tuple[List[Dict], Dict[str, str], Dict[str, float]]:
+        """Return serialized transactions, category map and budget targets."""
+        txns = self.serialize_transactions(self.get_transactions(user))
+        category_map = self.get_category_map(user)
+        budget_targets = self.get_budget_targets(user)
+        return txns, category_map, budget_targets
+
+    def send_message(self, user: get_user_model(), text: str) -> Message:
+        """Persist the user text, run the agent flow and store the reply."""
+        conversation = self.get_conversation(user)
+        Message.objects.create(
+            conversation=conversation,
+            sender=Message.USER,
+            content_type=Message.TEXT,
+            payload={"text": text},
+        )
+
+        txns, category_map, budget_targets = self.build_financial_context(user)
+
+        content_type, payload = self.orchestrator.handle_message(
+            text,
+            transactions=txns,
+            category_map=category_map,
+            budget_targets=budget_targets,
+        )
+        agent_msg = Message.objects.create(
+            conversation=conversation,
+            sender=Message.AGENT,
+            content_type=content_type,
+            payload=payload,
+        )
+        return agent_msg

--- a/finance/settings.py
+++ b/finance/settings.py
@@ -147,16 +147,24 @@ WSGI_APPLICATION = 'finance.wsgi.application'
 # 	}
 # }
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        "NAME": config("DB_NAME", default="test"),
-        "USER": config("DB_USER", default="test"),
-        "PASSWORD": config("DB_PASSWORD", default="test"),
-        'HOST': config("HOST", default="test"),
-        'PORT': '5432',
+if os.environ.get("USE_SQLITE_FOR_TESTS") == "1":
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.sqlite3",
+            "NAME": ":memory:",
+        }
     }
-}
+else:
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.postgresql_psycopg2',
+            "NAME": config("DB_NAME", default="test"),
+            "USER": config("DB_USER", default="test"),
+            "PASSWORD": config("DB_PASSWORD", default="test"),
+            'HOST': config("HOST", default="test"),
+            'PORT': '5432',
+        }
+    }
 
 # Password validation
 # https://docs.djangoproject.com/en/2.2/ref/settings/#auth-password-validators

--- a/finance/test_settings.py
+++ b/finance/test_settings.py
@@ -1,0 +1,8 @@
+from .settings import *  # noqa
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+    }
+}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-DJANGO_SETTINGS_MODULE = finance.settings
+DJANGO_SETTINGS_MODULE = finance.test_settings
 python_files = tests.py test_*.py *_tests.py

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import json
 import pytest
 
 # ensure required settings for Django
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "finance.settings")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "finance.test_settings")
 for var in [
     "GRID_ENDPOINT",
     "FRONT_ENDPOINT",

--- a/tests/test_chat_service.py
+++ b/tests/test_chat_service.py
@@ -1,0 +1,70 @@
+import datetime
+
+import pytest
+from django.contrib.auth import get_user_model
+
+from app.services.chat_service import ChatService
+from app.models import Message
+from myFinance.models import (
+    Tag,
+    TransactionNameTag,
+    TagGoal,
+    Transaction,
+    DateInput,
+)
+
+
+@pytest.mark.django_db
+def test_send_message_creates_reply(orchestrator_llm):
+    user = get_user_model().objects.create_user(username="tester", password="pass")
+    service = ChatService()
+    msg = service.send_message(user, "show me a chart")
+
+    assert msg.sender == Message.AGENT
+    assert msg.content_type == Message.CHART
+
+    conv = service.get_conversation(user)
+    assert conv.messages.count() == 2
+
+
+@pytest.mark.django_db
+def test_build_financial_context(monkeypatch):
+    user = get_user_model().objects.create_user(username="ctx", password="pass")
+
+    DateInput.objects.create(user=user, name="start_date", date=datetime.date.today())
+
+    tag = Tag.objects.create(user=user, name="Food", key="food")
+    TransactionNameTag.objects.create(user=user, transaction_name="Shop", tag=tag)
+    TagGoal.objects.create(user=user, tag=tag, value=250)
+    Transaction.objects.create(user=user, name="Shop", value=10, date=datetime.date.today(), tag=tag)
+
+    service = ChatService()
+    txns, category_map, budgets = service.build_financial_context(user)
+
+    assert len(txns) == 1
+    assert category_map == {"Shop": "Food"}
+    assert budgets == {"Food": 250}
+
+
+@pytest.mark.django_db
+def test_send_message_passes_context(monkeypatch):
+    user = get_user_model().objects.create_user(username="patch", password="pass")
+
+    Tag.objects.create(user=user, name="Other", key="other")
+
+    service = ChatService()
+
+    captured = {}
+
+    def fake_handle_message(text, **kwargs):
+        captured.update(kwargs)
+        return Message.TEXT, {"text": "ok"}
+
+    monkeypatch.setattr(service.orchestrator, "handle_message", fake_handle_message)
+
+    service.send_message(user, "cash flow please")
+
+    assert "transactions" in captured
+    assert "category_map" in captured
+    assert "budget_targets" in captured
+


### PR DESCRIPTION
## Summary
- implement `ChatService` for ORM access
- use `ChatService` in views
- add tests for new service and use SQLite settings for pytest
- extend chat service with financial context

## Testing
- `pytest -q`
