### PR TITLE
Implement conversation agent and update schemas

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -6,6 +6,7 @@ from .safety import SafetyAgent
 from .tax_pension import TaxPensionAgent
 from .investment import InvestmentAgent
 from .reporting import ReportingAgent
+from .conversation import ConversationAgent
 from .workflow import run_workflow, workflow
 
 __all__ = [
@@ -17,6 +18,7 @@ __all__ = [
     "TaxPensionAgent",
     "InvestmentAgent",
     "ReportingAgent",
+    "ConversationAgent",
     "workflow",
     "run_workflow",
 ]

--- a/agents/conversation.py
+++ b/agents/conversation.py
@@ -1,0 +1,16 @@
+from .base import BaseAgent
+from app.models import Message
+
+class ConversationAgent(BaseAgent):
+    """Summarise Data-lane outputs into user-facing text."""
+
+    name = "conversation"
+    schema_file = None
+
+    def handle_message(self, text: str, *, source: str, agent: str, payload: dict) -> tuple[str, dict]:
+        summary = f"{agent} completed"
+        missing = payload.get("missing_info") if isinstance(payload, dict) else None
+        if missing:
+            summary += ": missing " + ", ".join(missing)
+        return Message.TEXT, {"messages": [summary]}
+

--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -12,6 +12,7 @@ from .safety import SafetyAgent
 from .tax_pension import TaxPensionAgent
 from .investment import InvestmentAgent
 from .reporting import ReportingAgent
+from .conversation import ConversationAgent
 from .debt_strategy import DebtStrategyAgent
 from .reminder_scheduler import ReminderSchedulerAgent
 from .compliance_privacy import CompliancePrivacyAgent
@@ -26,6 +27,7 @@ class Orchestrator(BaseAgent):
 
     def __init__(self):
         self.agents = {
+            "conversation": ConversationAgent(),
             "onboarding": OnboardingAgent(),
             "cash_flow": CashFlowAgent(),
             "goal_setting": GoalSettingAgent(),
@@ -49,6 +51,7 @@ class Orchestrator(BaseAgent):
             "Debt-Strategy": "debt_strategy",
             "Review & Reminder Scheduler": "reminder_scheduler",
             "Compliance & Privacy": "compliance_privacy",
+            "Conversation": "conversation",
         }
 
     def _heuristic_route(self, text: str) -> str:
@@ -131,6 +134,12 @@ class Orchestrator(BaseAgent):
             # Other agents currently ignore intent
             pass
 
-        result = self.agents[agent_key].handle_message(text, **kwargs)
-        logger.debug("Agent %s returned %s", agent_key, result[0])
-        return result
+        content_type, payload = self.agents[agent_key].handle_message(text, **kwargs)
+        logger.debug("Agent %s returned %s", agent_key, content_type)
+
+        if agent_key != "conversation":
+            content_type, payload = self.agents["conversation"].handle_message(
+                text, source="Data", agent=agent_key, payload=payload
+            )
+
+        return content_type, payload

--- a/agents/prompt/system_prompt/conversation.md
+++ b/agents/prompt/system_prompt/conversation.md
@@ -1,0 +1,10 @@
+# Conversation Agent System Prompt
+You are the CONVERSATION agent. You summarise outputs from data agents and provide short next-step guidance.
+Return exactly one JSON object:
+
+```json
+{ "messages": ["<bubble1>", "<bubble2>"] }
+```
+
+No markdown fences or additional prose. If you cannot comply, reply with `{}`.
+

--- a/agents/schema/BaselineSnapshot.json
+++ b/agents/schema/BaselineSnapshot.json
@@ -24,7 +24,11 @@
   
       "monthly_income":  { "type": "number" },
       "monthly_expenses":{ "type": "number" },
-      "notes":           { "type": "string" }
+      "notes":           { "type": "string" },
+      "missing_info": {
+        "type": "array",
+        "items": { "type": "string" }
+      }
     },
   
     "definitions": {

--- a/agents/schema/BudgetPlan.json
+++ b/agents/schema/BudgetPlan.json
@@ -22,6 +22,10 @@
         }
       },
       "savings_rate_target":{"type":"number","minimum":0,"maximum":1},
-      "notes":{"type":"string"}
+      "notes":{"type":"string"},
+      "missing_info":{
+        "type":"array",
+        "items":{"type":"string"}
+      }
     }
   }

--- a/agents/schema/CashFlowLedger.json
+++ b/agents/schema/CashFlowLedger.json
@@ -16,6 +16,10 @@
       "category_map":{
         "type":"object",
         "description":"user-defined overrides, key=merchant|description regex, value=category"
+      },
+      "missing_info":{
+        "type":"array",
+        "items":{"type":"string"}
       }
     },
   

--- a/agents/schema/DebtStrategy.json
+++ b/agents/schema/DebtStrategy.json
@@ -16,6 +16,10 @@
       "payoff_schedule":{
         "type":"array",
         "items":{"$ref":"ScheduleEntry"}
+      },
+      "missing_info":{
+        "type":"array",
+        "items":{"type":"string"}
       }
     },
   

--- a/agents/schema/GoalList.json
+++ b/agents/schema/GoalList.json
@@ -7,6 +7,10 @@
       "goals": {
         "type":"array",
         "items": { "$ref":"Goal" }
+      },
+      "missing_info":{
+        "type":"array",
+        "items":{"type":"string"}
       }
     },
   

--- a/agents/schema/InvestmentPortfolio.json
+++ b/agents/schema/InvestmentPortfolio.json
@@ -24,6 +24,10 @@
       "recommended_trades":{
         "type":"array",
         "items":{"$ref":"Trade"}
+      },
+      "missing_info":{
+        "type":"array",
+        "items":{"type":"string"}
       }
     },
   
@@ -54,3 +58,4 @@
       }
     }
   }
+

--- a/agents/schema/ReminderTask.json
+++ b/agents/schema/ReminderTask.json
@@ -10,5 +10,9 @@
       "next_run":  {"type":"string","format":"date-time"},
       "status":    {"type":"string","enum":["scheduled","completed","paused","cancelled"]},
       "related_object_id":{"type":"string"}
+      ,"missing_info":{
+        "type":"array",
+        "items":{"type":"string"}
+      }
     }
   }

--- a/agents/schema/Report.json
+++ b/agents/schema/Report.json
@@ -9,6 +9,10 @@
       "generated_at":{"type":"string","format":"date-time"},
       "source_refs":{"type":"array","items":{"type":"string"}},
       "chart_url":{"type":"string","format":"uri"},
-      "summary_markdown":{"type":"string"}
+      "summary_markdown":{"type":"string"},
+      "missing_info":{
+        "type":"array",
+        "items":{"type":"string"}
+      }
     }
   }

--- a/agents/schema/SafetyLayer.json
+++ b/agents/schema/SafetyLayer.json
@@ -18,6 +18,10 @@
       "estate_documents":{
         "type":"array",
         "items":{"$ref":"EstateDoc"}
+      },
+      "missing_info":{
+        "type":"array",
+        "items":{"type":"string"}
       }
     },
   

--- a/agents/schema/SecurityAuditRecord.json
+++ b/agents/schema/SecurityAuditRecord.json
@@ -9,6 +9,10 @@
       "action":{"type":"string","enum":["scrub","delete","redact","access"]},
       "actor":{"type":"string"},
       "object_id":{"type":"string"},
-      "details":{"type":"string"}
+      "details":{"type":"string"},
+      "missing_info":{
+        "type":"array",
+        "items":{"type":"string"}
+      }
     }
   }

--- a/agents/schema/TaxPensionProfile.json
+++ b/agents/schema/TaxPensionProfile.json
@@ -18,6 +18,10 @@
       "recommendations":{
         "type":"array",
         "items":{"type":"string"}
+      },
+      "missing_info":{
+        "type":"array",
+        "items":{"type":"string"}
       }
     },
   

--- a/tests/test_chat_service.py
+++ b/tests/test_chat_service.py
@@ -21,7 +21,7 @@ def test_send_message_creates_reply(orchestrator_llm):
     msg = service.send_message(user, "show me a chart")
 
     assert msg.sender == Message.AGENT
-    assert msg.content_type == Message.CHART
+    assert msg.content_type == Message.TEXT
 
     conv = service.get_conversation(user)
     assert conv.messages.count() == 2

--- a/tests/test_conversation_agent.py
+++ b/tests/test_conversation_agent.py
@@ -1,0 +1,15 @@
+from agents.conversation import ConversationAgent
+from app.models import Message
+
+
+def test_conversation_agent_summarises():
+    agent = ConversationAgent()
+    content_type, payload = agent.handle_message(
+        "",
+        source="Data",
+        agent="onboarding",
+        payload={"missing_info": ["bank", "credit"]},
+    )
+    assert content_type == Message.TEXT
+    assert "missing" in payload["messages"][0]
+

--- a/tests/test_full_workflow.py
+++ b/tests/test_full_workflow.py
@@ -4,5 +4,5 @@ from app.models import Message
 
 def test_full_workflow():
     state = run_workflow("I want to sign up and then see a chart")
-    assert state.result["content_type"] == Message.CHART
-    assert state.conversation[-1]["agent"] == "reporting"
+    assert state.result["content_type"] == Message.TEXT
+    assert state.conversation[-1]["agent"] == "conversation"

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -4,23 +4,25 @@ from app.models import Message
 
 def test_reporting_route():
     state = run_workflow("show me a chart")
-    assert state.result["content_type"] == Message.CHART
-    assert [step["agent"] for step in state.conversation] == ["orchestrator", "reporting"]
+    assert state.result["content_type"] == Message.TEXT
+    assert [step["agent"] for step in state.conversation] == ["orchestrator", "reporting", "conversation"]
 
 
 def test_safety_route():
     state = run_workflow("tell me about safety")
     assert state.result["content_type"] == Message.TEXT
-    assert [step["agent"] for step in state.conversation] == ["orchestrator", "safety"]
+    assert [step["agent"] for step in state.conversation] == ["orchestrator", "safety", "conversation"]
 
 
 def test_onboarding_then_reporting():
     state = run_workflow("hello")
-    assert state.result["content_type"] == Message.CHART
+    assert state.result["content_type"] == Message.TEXT
     assert [step["agent"] for step in state.conversation] == [
         "orchestrator",
         "onboarding",
+        "conversation",
         "reporting",
+        "conversation",
     ]
 
 
@@ -37,4 +39,5 @@ def test_other_routes():
         assert [step["agent"] for step in state.conversation] == [
             "orchestrator",
             expected,
+            "conversation",
         ]


### PR DESCRIPTION
## Summary
- add new `ConversationAgent` for summarising data outputs
- route all data agents through the ConversationAgent
- update workflow graph to include conversation step
- extend all agent schemas with optional `missing_info`
- adjust tests for new conversation flow and add dedicated tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b314b7c848326b7e75c783ab0eb2a