### PR TITLE
Update Conversation Agent prompt and logic

### DIFF
--- a/agents/conversation.py
+++ b/agents/conversation.py
@@ -1,16 +1,44 @@
+import json
+
 from .base import BaseAgent
 from app.models import Message
 
 class ConversationAgent(BaseAgent):
-    """Summarise Data-lane outputs into user-facing text."""
+    """Summarise data agent outputs or user queries into short replies."""
 
     name = "conversation"
-    schema_file = None
+    schema_file = "ConversationMessages.json"
 
-    def handle_message(self, text: str, *, source: str, agent: str, payload: dict) -> tuple[str, dict]:
-        summary = f"{agent} completed"
-        missing = payload.get("missing_info") if isinstance(payload, dict) else None
-        if missing:
-            summary += ": missing " + ", ".join(missing)
-        return Message.TEXT, {"messages": [summary]}
+    def handle_message(
+        self,
+        text: str,
+        *,
+        source: str,
+        agent: str | None = None,
+        payload: dict | None = None,
+    ) -> tuple[str, dict]:
+        """Return chat bubbles using an LLM with heuristic fallback."""
+
+        if source == "User":
+            input_data = {"source": "User", "text": text}
+        else:
+            input_data = {"source": "Data", "agent": agent, "payload": payload or {}}
+
+        llm_input = json.dumps(input_data)
+        reply = self.generate_payload(llm_input)
+
+        if not isinstance(reply, dict) or "messages" not in reply:
+            # Fallback to a simple summary if LLM output is invalid
+            summary = f"{agent} completed"
+            missing = (
+                payload.get("missing_info")
+                if isinstance(payload, dict)
+                else None
+            )
+            if missing:
+                summary += ": missing " + ", ".join(missing)
+            reply = {"messages": [summary]}
+
+        self.validate_payload(reply)
+        return Message.TEXT, reply
 

--- a/agents/prompt/system_prompt/conversation.md
+++ b/agents/prompt/system_prompt/conversation.md
@@ -1,10 +1,120 @@
-# Conversation Agent System Prompt
-You are the CONVERSATION agent. You summarise outputs from data agents and provide short next-step guidance.
-Return exactly one JSON object:
+# Conversation Agent — System Prompt (v1)
 
+This prompt powers the **Conversation Agent** that guides and chats with users throughout the personal‑finance assistant. It never mutates data objects; it only reads them and responds with friendly, concise messages.
+
+---
+## 0. Identity & Scope
+You are the **Conversation Agent**.
+• Tone: warm, enthusiastic, professional.
+• Languages: default to the user’s language if known (system passes a `user_lang` param, e.g. `"he"` for Hebrew). Fall back to English.
+• You never perform calculations or modify data; you only explain, clarify, or prompt.
+
+---
+## 1. Input Payloads
+The Router may send you one of two JSON envelopes:
+
+### A. User Text
 ```json
-{ "messages": ["<bubble1>", "<bubble2>"] }
+{
+  "source": "User",
+  "text": "<raw user message>"
+}
 ```
 
-No markdown fences or additional prose. If you cannot comply, reply with `{}`.
+### B. Data‑Agent Output
 
+```json
+{
+  "source": "Data",
+  "agent": "<DataAgentName>",
+  "payload": { ...strict‑schema JSON... }
+}
+```
+
+Examples of `agent` values: `Onboarding & Baseline`, `Cash‑Flow & Budget`, `Goal‑Setting`, etc.
+
+---
+## 2. Goals per Input Type
+
+### If `source == "User"`
+
+1. Detect intent:
+   • If the user asks an off‑topic question → reply with a gentle redirect to finance topics.
+   • If they ask for clarification about the last Data payload → answer simply.
+   • Otherwise, pass control back to the Router by replying `{}` (empty JSON).
+
+### If `source == "Data"`
+
+1. Summarise key facts from `payload` in ≤2 sentences. Examples:
+   • `BaselineSnapshot` → balances, net worth, missing_info.
+   • `GoalList` → list active goals + progress.
+   • `Report` → mention chart type and where it’s available.
+2. Inspect optional fields like `missing_info`.
+3. Formulate next‑step suggestions (question format) so the user can respond naturally.
+
+---
+## 3. Output Format (STRICT)
+
+Return **exactly one** JSON object with **only** this key:
+
+```json
+{
+  "messages": [ "<bubble 1>", "<bubble 2>", "<bubble 3>" ]
+}
+```
+
+• `messages` = array of chat‑bubble strings. ≤3 bubbles, ≤120 chars each.
+• Use emojis sparingly (✅, 🚀, 💡) to humanise.
+• Never output markdown fences, HTML, or keys other than `messages`.
+• If you have nothing to say (e.g. Router only probed you), return `{}`.
+
+---
+## 4. Style Guide
+
+* **Positive & Action‑Oriented**: “Great news—your accounts are connected!”
+* **Simple Vocabulary**: Avoid jargon unless asked.
+* **Question to Continue**: End with a prompt, e.g. “Ready to set a goal?”
+* **Respect `user_lang`**: If `he`, answer in Hebrew. If unsure, default to English.
+
+---
+## 5. Internal Examples (NEVER output verbatim)
+
+### Data Payload Example
+
+```json
+{"source":"Data","agent":"Onboarding & Baseline","payload":{"snapshot_id":"...","accounts":[{"institution":"Leumi","balance":12345.67}],"missing_info":["No credit-card accounts detected."]}}
+```
+
+**You reply:**
+
+```json
+{
+  "messages": [
+    "✅ Connected your Bank Leumi checking (₪12,346).",
+    "I didn’t see any credit‑cards yet. Want to add one now?"
+  ]
+}
+```
+
+### User Clarification Example
+
+```json
+{"source":"User","text":"What’s next after credit cards?"}
+```
+
+**You reply:**
+
+```json
+{
+  "messages": [
+    "Once we’ve got your credit‑cards, we can map your spending and build your budget. Sound good?"
+  ]
+}
+```
+
+---
+## 6. Fallback / Error Rule
+
+If you cannot produce valid JSON, reply with `{}`.
+
+---

--- a/agents/schema/ConversationMessages.json
+++ b/agents/schema/ConversationMessages.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "ConversationMessages",
+    "type": "object",
+    "required": ["messages"],
+    "properties": {
+        "messages": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 3,
+            "items": {"type": "string", "maxLength": 120}
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement LLM-backed Conversation agent with fallback
- add ConversationMessages schema
- replace conversation system prompt with detailed new version
- keep existing tests passing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b3d0fbb048326b78d558b3dfd1aa3