### PR TITLE
Implement capability manifest

### DIFF
--- a/README
+++ b/README
@@ -86,6 +86,8 @@ dependencies listed in `docs/react_native_migration.md`.
 - The backend and frontend can be started independently.
 - For production, additional configuration may be required.
 - The new FinanceAgent app (web/mobile) lives in `front/FinanceAgent`. See its README for details.
+- `scripts/generate_manifest.py` builds `capability_manifest.json` from the
+  agent prompts. Run it whenever you update intents or descriptions.
 
 ---
 

--- a/agents/conversation.py
+++ b/agents/conversation.py
@@ -1,6 +1,8 @@
 import json
+from typing import Any
 
 from .base import BaseAgent
+from .manifest import load_manifest
 from app.models import Message
 
 class ConversationAgent(BaseAgent):
@@ -8,6 +10,18 @@ class ConversationAgent(BaseAgent):
 
     name = "conversation"
     schema_file = "ConversationMessages.json"
+
+    def __init__(self, manifest_path: str | None = None) -> None:
+        self.manifest = load_manifest(manifest_path)
+
+    def system_prompt(self) -> str:
+        base = super().system_prompt()
+        caps = [
+            {"name": a["name"], "user_friendly": a.get("user_friendly", "")}
+            for a in self.manifest.get("agents", [])
+        ]
+        manifest_obj = json.dumps({"capabilities": caps}, ensure_ascii=False)
+        return base + "\n" + manifest_obj
 
     def handle_message(
         self,

--- a/agents/manifest.py
+++ b/agents/manifest.py
@@ -1,0 +1,15 @@
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+# Default manifest location is project root
+DEFAULT_PATH = Path(__file__).resolve().parents[1] / 'capability_manifest.json'
+
+
+def load_manifest(path: str | Path | None = DEFAULT_PATH) -> Dict[str, Any]:
+    """Load and return the capability manifest."""
+    if path is None:
+        path = DEFAULT_PATH
+    path = Path(path)
+    with path.open() as f:
+        return json.load(f)

--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from typing import Tuple, Dict
 
@@ -16,6 +15,7 @@ from .conversation import ConversationAgent
 from .debt_strategy import DebtStrategyAgent
 from .reminder_scheduler import ReminderSchedulerAgent
 from .compliance_privacy import CompliancePrivacyAgent
+from .manifest import load_manifest
 
 logger = logging.getLogger(__name__)
 
@@ -25,9 +25,10 @@ class Orchestrator(BaseAgent):
 
     name = "orchestrator"
 
-    def __init__(self):
+    def __init__(self, manifest_path: str | None = None):
+        self.manifest = load_manifest(manifest_path)
         self.agents = {
-            "conversation": ConversationAgent(),
+            "conversation": ConversationAgent(manifest_path),
             "onboarding": OnboardingAgent(),
             "cash_flow": CashFlowAgent(),
             "goal_setting": GoalSettingAgent(),
@@ -39,19 +40,9 @@ class Orchestrator(BaseAgent):
             "reminder_scheduler": ReminderSchedulerAgent(),
             "compliance_privacy": CompliancePrivacyAgent(),
         }
-        # Map human-readable agent names from the system prompt to keys
+        # Map human-readable agent names from the manifest to keys
         self.agent_name_map = {
-            "Onboarding & Baseline": "onboarding",
-            "Cash-Flow & Budget": "cash_flow",
-            "Goal-Setting": "goal_setting",
-            "Safety-Layer": "safety",
-            "Tax & Pension Optimiser": "tax_pension",
-            "Investment Architect": "investment",
-            "Reporting & Visualisation": "reporting",
-            "Debt-Strategy": "debt_strategy",
-            "Review & Reminder Scheduler": "reminder_scheduler",
-            "Compliance & Privacy": "compliance_privacy",
-            "Conversation": "conversation",
+            entry["name"]: entry["key"] for entry in self.manifest.get("agents", [])
         }
 
     def _heuristic_route(self, text: str) -> str:

--- a/capability_manifest.json
+++ b/capability_manifest.json
@@ -1,0 +1,93 @@
+{
+  "capability_version": 1,
+  "agents": [
+    {
+      "key": "onboarding",
+      "name": "Onboarding & Baseline",
+      "intents": [
+        "upload_documents",
+        "update_accounts"
+      ],
+      "user_friendly": "Connect accounts, parse bank/credit statements, and build your first net-worth snapshot."
+    },
+    {
+      "key": "cash_flow",
+      "name": "Cash-Flow & Budget",
+      "intents": [
+        "categorize_txns"
+      ],
+      "user_friendly": "Categorise your transactions and build a personalised budget."
+    },
+    {
+      "key": "goal_setting",
+      "name": "Goal-Setting",
+      "intents": [
+        "set_goal",
+        "list_goals"
+      ],
+      "user_friendly": "Create and track SMART savings or investment goals."
+    },
+    {
+      "key": "safety",
+      "name": "Safety-Layer",
+      "intents": [
+        "assess_safety"
+      ],
+      "user_friendly": "Flag suspicious activity and ensure account security."
+    },
+    {
+      "key": "tax_pension",
+      "name": "Tax & Pension Optimiser",
+      "intents": [
+        "tax_optimiser"
+      ],
+      "user_friendly": "Recommend tax strategies and pension options."
+    },
+    {
+      "key": "investment",
+      "name": "Investment Architect",
+      "intents": [
+        "plan_investment"
+      ],
+      "user_friendly": "Plan your investment portfolio."
+    },
+    {
+      "key": "reporting",
+      "name": "Reporting & Visualisation",
+      "intents": [
+        "show_net_worth",
+        "show_budget",
+        "create_report"
+      ],
+      "user_friendly": "Create charts and reports from your finances."
+    },
+    {
+      "key": "debt_strategy",
+      "name": "Debt-Strategy",
+      "intents": [
+        "debt_strategy"
+      ],
+      "user_friendly": "Optimise debt repayments or consolidation."
+    },
+    {
+      "key": "reminder_scheduler",
+      "name": "Review & Reminder Scheduler",
+      "intents": [
+        "schedule_review"
+      ],
+      "user_friendly": "Schedule periodic reviews and reminders."
+    },
+    {
+      "key": "compliance_privacy",
+      "name": "Compliance & Privacy",
+      "intents": [],
+      "user_friendly": "Manage privacy requests and data compliance."
+    },
+    {
+      "key": "conversation",
+      "name": "Conversation",
+      "intents": [],
+      "user_friendly": "General conversation and user guidance."
+    }
+  ]
+}

--- a/scripts/generate_manifest.py
+++ b/scripts/generate_manifest.py
@@ -1,0 +1,92 @@
+import json
+from pathlib import Path
+
+# Paths relative to repository root
+ROOT = Path(__file__).resolve().parents[1]
+INTENTS_FILE = ROOT / 'agents' / 'prompt' / 'system_prompt' / 'intents.json'
+OUTPUT_FILE = ROOT / 'capability_manifest.json'
+
+# Human friendly descriptions per agent key
+AGENT_INFO = {
+    'onboarding': (
+        'Onboarding & Baseline',
+        'Connect accounts, parse bank/credit statements, and build your first net-worth snapshot.'
+    ),
+    'cash_flow': (
+        'Cash-Flow & Budget',
+        'Categorise your transactions and build a personalised budget.'
+    ),
+    'goal_setting': (
+        'Goal-Setting',
+        'Create and track SMART savings or investment goals.'
+    ),
+    'safety': (
+        'Safety-Layer',
+        'Flag suspicious activity and ensure account security.'
+    ),
+    'tax_pension': (
+        'Tax & Pension Optimiser',
+        'Recommend tax strategies and pension options.'
+    ),
+    'investment': (
+        'Investment Architect',
+        'Plan your investment portfolio.'
+    ),
+    'reporting': (
+        'Reporting & Visualisation',
+        'Create charts and reports from your finances.'
+    ),
+    'debt_strategy': (
+        'Debt-Strategy',
+        'Optimise debt repayments or consolidation.'
+    ),
+    'reminder_scheduler': (
+        'Review & Reminder Scheduler',
+        'Schedule periodic reviews and reminders.'
+    ),
+    'compliance_privacy': (
+        'Compliance & Privacy',
+        'Manage privacy requests and data compliance.'
+    ),
+    'conversation': (
+        'Conversation',
+        'General conversation and user guidance.'
+    ),
+}
+
+
+def build_manifest() -> dict:
+    """Return manifest dictionary built from intents.json and AGENT_INFO."""
+    with open(INTENTS_FILE) as f:
+        intents_map = json.load(f)
+
+    agent_intents = {key: [] for key in AGENT_INFO}
+    # intents.json maps intent -> {agent: FriendlyName}
+    name_to_key = {info[0]: key for key, info in AGENT_INFO.items()}
+
+    for intent, data in intents_map.items():
+        name = data.get('agent')
+        key = name_to_key.get(name)
+        if key:
+            agent_intents[key].append(intent)
+
+    agents = []
+    for key, (name, desc) in AGENT_INFO.items():
+        agents.append({
+            'key': key,
+            'name': name,
+            'intents': agent_intents.get(key, []),
+            'user_friendly': desc,
+        })
+
+    return {'capability_version': 1, 'agents': agents}
+
+
+def main() -> None:
+    manifest = build_manifest()
+    OUTPUT_FILE.write_text(json.dumps(manifest, indent=2))
+    print(f'Wrote manifest to {OUTPUT_FILE}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `capability_manifest.json` with names, intents and descriptions
- add script `scripts/generate_manifest.py` to build the manifest
- expose capability manifest via `load_manifest`
- integrate manifest into `ConversationAgent` and `Orchestrator`
- document manifest generation in README

## Testing
- `pytest -q` *(fails: ImportError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_e_683b40d2ed988326a9d079f1e94d6cf3