### PR TITLE
Add budget info requirements to cash-flow agent

### DIFF
--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -146,6 +146,7 @@ class Orchestrator(BaseAgent):
                 transactions=context.get("transactions"),
                 category_map=context.get("category_map"),
                 budget_targets=context.get("budget_targets"),
+                budget_info=context.get("budget_info"),
             )
         elif agent_key == "conversation":
             # Pass intent and params to conversation agent for direct user interactions

--- a/agents/prompt/system_prompt/cash_flow.md
+++ b/agents/prompt/system_prompt/cash_flow.md
@@ -6,6 +6,19 @@ You are the **Cash‑Flow & Budget Agent**.  You categorise transactions, comput
 * `intent`: `categorize_txns` or `create_budget`
 * `transactions[]` — array of raw transaction rows (id, date, description, amount, currency, account\_id)
 * optional `category_map` overrides or `budget_targets`
+* optional `budget_info` details for building budgets
+
+When drafting a budget you **require** these fields inside `budget_info`:
+1. **net_income** – regular pay plus bonuses or side gigs
+2. **fixed_essentials** – housing, debt, utilities, insurance
+3. **variable_costs** – food, transport, entertainment, etc.
+4. **infrequent_costs** – car maintenance, holidays, repairs, fees
+5. **savings_investing** – pension plans, brokerage, emergency fund
+6. **balances_today** – assets vs. loans and credit cards
+7. **goals_preferences** – timelines, risk tolerance, lifestyle
+8. **logistics** – preferred currency, apps, budget delivery method
+
+If any required field is missing you must return `{"missing_info": [...]}` listing them.
 
 **Task & Output Schema**
 

--- a/tests/test_cash_flow_agent.py
+++ b/tests/test_cash_flow_agent.py
@@ -1,0 +1,15 @@
+import pytest
+from agents.cash_flow import CashFlowAgent
+from app.models import Message
+
+
+def test_create_budget_requires_fields():
+    agent = CashFlowAgent()
+    content_type, payload = agent.handle_message(
+        "create my budget",
+        intent="create_budget",
+        budget_info={},
+    )
+    assert content_type == Message.TEXT
+    assert "missing_info" in payload
+    assert "net_income" in payload["missing_info"]

--- a/tests/test_chat_service.py
+++ b/tests/test_chat_service.py
@@ -67,4 +67,24 @@ def test_send_message_passes_context(monkeypatch):
     assert "transactions" in captured
     assert "category_map" in captured
     assert "budget_targets" in captured
+    assert "budget_info" in captured
+
+
+@pytest.mark.django_db
+def test_get_budget_inputs_returns_mock():
+    user = get_user_model().objects.create_user(username="budget", password="pass")
+    service = ChatService()
+    data = service.get_budget_inputs(user)
+    required = [
+        "net_income",
+        "fixed_essentials",
+        "variable_costs",
+        "infrequent_costs",
+        "savings_investing",
+        "balances_today",
+        "goals_preferences",
+        "logistics",
+    ]
+    for field in required:
+        assert field in data
 


### PR DESCRIPTION
## Summary
- expand `CashFlowAgent` to require detailed `budget_info`
- store and pass placeholder budget info from `ChatService`
- route new info through the orchestrator
- document required fields in the cash-flow system prompt
- test passing context and missing-info behaviour
- **add mock budget data in ChatService**

## Testing
- `docker-compose -f docker-compose.test.yml run --build test` *(fails: command not found)*
- `pytest -q` *(fails: No module named 'selenium')*


------
https://chatgpt.com/codex/tasks/task_e_683c203988388326b4bde3e97372c0f3