### PR TITLE
Add ADK specific requirements file

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -100,6 +100,9 @@ The `agents_adk/` directory contains a modern, ADK-based agent system that repla
 cp agents_adk/env_template agents_adk/.env
 # Add your Google API key to .env
 
+# Install minimal dependencies for the ADK agent system
+pip install -r requirements/adk.txt
+
 # Test the system
 cd agents_adk && python test_adk.py
 

--- a/README
+++ b/README
@@ -12,8 +12,11 @@
    ```sh
    # Base packages
    pip install --index-url https://pypi.org/simple -r requirements/base.txt
+
+   # Only the ADK agent system (minimal Django + ADK deps)
+   pip install --index-url https://pypi.org/simple -r requirements/adk.txt
    ```
-   Additional requirement files live in the new `requirements/` directory. Install
+   Additional requirement files live in the `requirements/` directory. Install
    `agents.txt`, `extras.txt` or `test.txt` as needed, or use `all.txt` to install
    everything.
 

--- a/requirements/adk.txt
+++ b/requirements/adk.txt
@@ -1,0 +1,23 @@
+# Minimal requirements for running the ADK-based finance agent system
+# Includes Django core packages and only the libraries needed by the ADK code
+Django==3.2.14
+django-graphos
+django-extensions
+django-bootstrap-modal-forms
+django-bstrap-modals
+djangorestframework
+python-decouple==3.6
+psycopg2-binary
+django-cors-headers
+django-filter==22.1
+celery
+django-kms-field
+django-celery-results
+django-celery-beat
+dj_rest_auth
+django-allauth
+blinker<1.8.0
+boto3
+drf-spectacular
+python-dotenv
+google-adk


### PR DESCRIPTION
## Summary
- add `requirements/adk.txt` for running only the ADK agent app
- mention the new file in setup instructions
- show how to install ADK dependencies in agent docs

## Testing
- `pytest -q` *(fails: Expected 12 agents, got 15)*

------
https://chatgpt.com/codex/tasks/task_e_683e261ef06083269040e348c9abe24b