### PR TITLE
Improve logging in agent service

### DIFF
--- a/services/agent_service/config.py
+++ b/services/agent_service/config.py
@@ -50,4 +50,4 @@ ADK_PROJECT_ID = config('ADK_PROJECT_ID', default='')
 ADK_REGION = config('ADK_REGION', default='us-central1')
 
 # Logging configuration
-LOG_FORMAT = '%(asctime)s - %(levelname)s - %(session)s - %(agent)s - %(message)s'
+LOG_FORMAT = '%(asctime)s [%(levelname)s] [%(session)s] [%(agent)s] %(message)s'

--- a/services/agent_service/logging_utils.py
+++ b/services/agent_service/logging_utils.py
@@ -1,14 +1,23 @@
 import logging
 from colorlog import ColoredFormatter
-from config import AGENT_LOG_LEVEL
+from config import AGENT_LOG_LEVEL, LOG_FORMAT
+
+
+class SafeColoredFormatter(ColoredFormatter):
+    """Colored formatter that inserts default values for custom fields."""
+
+    def format(self, record: logging.LogRecord) -> str:  # type: ignore[override]
+        record.session = getattr(record, "session", "-")
+        record.agent = getattr(record, "agent", "-")
+        return super().format(record)
 
 
 def setup_logging() -> None:
     """Configure colored logging for the agent service."""
     level = getattr(logging, AGENT_LOG_LEVEL.upper(), logging.INFO)
 
-    formatter = ColoredFormatter(
-        fmt="%(log_color)s%(asctime)s [%(levelname)s] %(session)s %(agent)s %(message)s",
+    formatter = SafeColoredFormatter(
+        fmt=f"%(log_color)s{LOG_FORMAT}%(reset)s",
         datefmt="%H:%M:%S",
         log_colors={
             'DEBUG': 'cyan',

--- a/services/agent_service/tests/unit/test_logging_utils.py
+++ b/services/agent_service/tests/unit/test_logging_utils.py
@@ -1,0 +1,16 @@
+import logging
+
+from services.agent_service.logging_utils import SafeColoredFormatter, setup_logging
+
+
+def test_safe_formatter_handles_missing_fields():
+    formatter = SafeColoredFormatter("%(log_color)s%(message)s%(reset)s", log_colors={"INFO": "green"})
+    record = logging.LogRecord("test", logging.INFO, __file__, 0, "hello", args=(), exc_info=None)
+    formatted = formatter.format(record)
+    assert "hello" in formatted
+
+
+def test_setup_logging_no_errors():
+    setup_logging()
+    logger = logging.getLogger("test_logger")
+    logger.info("hello")


### PR DESCRIPTION
## Summary
- provide formatting string constant for logs
- add SafeColoredFormatter that sets default session/agent values
- update setup_logging to use improved format
- test SafeColoredFormatter and logging setup

## Testing
- `pytest services/agent_service/tests/unit/test_logging_utils.py -vv`
- `pytest services/agent_service/tests`

------
https://chatgpt.com/codex/tasks/task_e_684405da4ae08326b4a1a5aeb194f7da