### PR TITLE
Improve logging in workflows

### DIFF
--- a/services/agent_service/agents_adk/workflows/finance_workflows.py
+++ b/services/agent_service/agents_adk/workflows/finance_workflows.py
@@ -4,7 +4,11 @@ These will be enhanced when full ADK workflow features become available.
 """
 
 from typing import Dict, Any, List
+import logging
+
 from ..state.workflow_state import FinanceSession, WorkflowState
+
+logger = logging.getLogger(__name__)
 
 
 class SimpleFinanceWorkflow:
@@ -17,11 +21,15 @@ class SimpleFinanceWorkflow:
         """Execute the workflow."""
         session = FinanceSession(user_id=user_id, session_id=f"{self.name}_{user_id}")
         workflow_state = WorkflowState(session=session, workflow_type=self.name)
+        extra = {"session": session.session_id, "agent": self.name}
+        logger.info("Starting workflow", extra=extra)
         
         try:
             # Basic workflow execution
             workflow_state.advance_to_step("started")
             workflow_state.complete_workflow()
+
+            logger.info("Workflow completed", extra=extra)
             
             return {
                 "success": True,
@@ -31,6 +39,7 @@ class SimpleFinanceWorkflow:
             }
         except Exception as e:
             workflow_state.add_error(f"Workflow error: {str(e)}")
+            logger.exception("Workflow failed", extra=extra)
             return {
                 "success": False,
                 "workflow": self.name,

--- a/services/agent_service/config.py
+++ b/services/agent_service/config.py
@@ -50,4 +50,5 @@ ADK_PROJECT_ID = config('ADK_PROJECT_ID', default='')
 ADK_REGION = config('ADK_REGION', default='us-central1')
 
 # Logging configuration
-LOG_FORMAT = '%(asctime)s - %(levelname)s - %(session)s - %(agent)s - %(message)s'
+LOG_FORMAT = '%(asctime)s [%(levelname)s] [%(session)s] [%(agent)s] %(message)s'
+

--- a/services/agent_service/logging_utils.py
+++ b/services/agent_service/logging_utils.py
@@ -1,14 +1,23 @@
 import logging
 from colorlog import ColoredFormatter
-from config import AGENT_LOG_LEVEL
+from config import AGENT_LOG_LEVEL, LOG_FORMAT
+
+
+class SafeColoredFormatter(ColoredFormatter):
+    """Colored formatter that inserts default values for custom fields."""
+
+    def format(self, record: logging.LogRecord) -> str:  # type: ignore[override]
+        record.session = getattr(record, "session", "-")
+        record.agent = getattr(record, "agent", "-")
+        return super().format(record)
 
 
 def setup_logging() -> None:
     """Configure colored logging for the agent service."""
     level = getattr(logging, AGENT_LOG_LEVEL.upper(), logging.INFO)
 
-    formatter = ColoredFormatter(
-        fmt="%(log_color)s%(asctime)s [%(levelname)s] %(session)s %(agent)s %(message)s",
+    formatter = SafeColoredFormatter(
+        fmt=f"%(log_color)s{LOG_FORMAT}%(reset)s",
         datefmt="%H:%M:%S",
         log_colors={
             'DEBUG': 'cyan',

--- a/services/agent_service/tests/unit/test_logging_utils.py
+++ b/services/agent_service/tests/unit/test_logging_utils.py
@@ -1,0 +1,16 @@
+import logging
+
+from services.agent_service.logging_utils import SafeColoredFormatter, setup_logging
+
+
+def test_safe_formatter_handles_missing_fields():
+    formatter = SafeColoredFormatter("%(log_color)s%(message)s%(reset)s", log_colors={"INFO": "green"})
+    record = logging.LogRecord("test", logging.INFO, __file__, 0, "hello", args=(), exc_info=None)
+    formatted = formatter.format(record)
+    assert "hello" in formatted
+
+
+def test_setup_logging_no_errors():
+    setup_logging()
+    logger = logging.getLogger("test_logger")
+    logger.info("hello")

--- a/services/agent_service/tests/unit/test_workflows.py
+++ b/services/agent_service/tests/unit/test_workflows.py
@@ -1,6 +1,7 @@
 """Unit tests for simplified finance workflows."""
 
 import asyncio
+import logging
 from services.agent_service.agents_adk.workflows.finance_workflows import (
     OnboardingWorkflow,
     BudgetCreationWorkflow,
@@ -42,3 +43,11 @@ def test_workflow_handles_error(monkeypatch):
     assert result["success"] is False
     assert result["workflow"] == "user_onboarding"
     assert "fail" in result["error"]
+
+
+def test_workflow_emits_logs(caplog):
+    caplog.set_level(logging.INFO)
+    workflow = OnboardingWorkflow()
+    asyncio.run(workflow.run("u1"))
+    assert any("Starting workflow" in rec.message for rec in caplog.records)
+    assert any("Workflow completed" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- provide constant `LOG_FORMAT` for logs
- implement SafeColoredFormatter for default fields
- update setup_logging to use improved format
- add workflow logging with `extra` fields
- test log output in workflows

## Testing
- `pytest services/agent_service/tests/unit/test_logging_utils.py -vv`
- `pytest services/agent_service/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_684405da4ae08326b4a1a5aeb194f7da